### PR TITLE
增加编译参数以添加对Alpine Linux的支持

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -29,22 +29,22 @@ sed -i.bak 's/$(wildcard .git),linux/$(wildcard .git),linux_check_disabled/g' "$
 
 # Build all the targets.
 targets=(
-#	'darwin amd64'
+	'darwin amd64'
 
 	'linux 386'
 	'linux amd64'
-#	'linux arm'
-#	'linux arm64'
-#	'linux ppc64'
-#	'linux ppc64le'
-#	'linux mips'
-#	'linux mipsle'
+	'linux arm'
+	'linux arm64'
+	'linux ppc64'
+	'linux ppc64le'
+	'linux mips'
+	'linux mipsle'
 
-#	'freebsd 386'
-#	'freebsd amd64'
-#	'freebsd arm'
+	'freebsd 386'
+	'freebsd amd64'
+	'freebsd arm'
 
-#	'openbsd amd64'
+	'openbsd amd64'
 )
 for target in "${targets[@]}"; do
 	target_=($target)

--- a/build.sh
+++ b/build.sh
@@ -29,22 +29,22 @@ sed -i.bak 's/$(wildcard .git),linux/$(wildcard .git),linux_check_disabled/g' "$
 
 # Build all the targets.
 targets=(
-	'darwin amd64'
+#	'darwin amd64'
 
 	'linux 386'
 	'linux amd64'
-	'linux arm'
-	'linux arm64'
-	'linux ppc64'
-	'linux ppc64le'
-	'linux mips'
-	'linux mipsle'
+#	'linux arm'
+#	'linux arm64'
+#	'linux ppc64'
+#	'linux ppc64le'
+#	'linux mips'
+#	'linux mipsle'
 
-	'freebsd 386'
-	'freebsd amd64'
-	'freebsd arm'
+#	'freebsd 386'
+#	'freebsd amd64'
+#	'freebsd arm'
 
-	'openbsd amd64'
+#	'openbsd amd64'
 )
 for target in "${targets[@]}"; do
 	target_=($target)
@@ -60,6 +60,7 @@ for target in "${targets[@]}"; do
 
 	export GOOS="$target_os"
 	export GOARCH="$target_arch"
+	export CGO_ENABLED=0
 
 	pushd "$src_dir" > /dev/null
 	make


### PR DESCRIPTION
默认情况下编译出的二进制文件会动态链接到GNU的C运行库glibc，但是Alpine默认采用的是musl libc库，编译出的程序会无法使用，因此添加了CGO_ENABLED=0参数来进行静态编译